### PR TITLE
Fix CPU usage calculation and HTML tag error

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ require_once 'auth.php';
                 <div class="card text-center shadow-sm border-0 bg-warning text-white">
                     <div class="card-body">
                         <h5 class="card-title">Uptime</h5>
-                        <h3 id="uptime" class="fw-bold">Cargando...</h2>
+                        <h3 id="uptime" class="fw-bold">Cargando...</h3>
                     </div>
                 </div>
             </div>
@@ -36,7 +36,7 @@ require_once 'auth.php';
                 <div class="card text-center shadow-sm border-0 bg-info text-white">
                     <div class="card-body">
                         <h5 class="card-title">Procesos Activos</h5>
-                        <h3 id="processCount" class="fw-bold">Cargando...</h2>
+                        <h3 id="processCount" class="fw-bold">Cargando...</h3>
                     </div>
                 </div>
             </div>
@@ -45,7 +45,7 @@ require_once 'auth.php';
                 <div class="card text-center shadow-sm border-0 bg-danger text-white">
                     <div class="card-body">
                         <h5 class="card-title">Usuarios Conectados</h5>
-                        <h3 id="connectedUsers" class="fw-bold">Cargando...</h2>
+                        <h3 id="connectedUsers" class="fw-bold">Cargando...</h3>
                     </div>
                 </div>
             </div>

--- a/metrics/cpu.php
+++ b/metrics/cpu.php
@@ -1,6 +1,11 @@
 <?php
 function obtenerUsoCPU() {
     $carga = sys_getloadavg();
-    return round($carga[0] * 100, 2);
+    $nucleos = intval(trim(shell_exec('nproc')));
+    if ($nucleos < 1) {
+        $nucleos = 1;
+    }
+    $porcentaje = ($carga[0] / $nucleos) * 100;
+    return round($porcentaje, 2);
 }
 ?>


### PR DESCRIPTION
## Summary
- improve CPU percentage calculation by considering number of cores
- fix closing `<h3>` tags in the dashboard markup

## Testing
- `php` not installed; unable to run syntax check

------
https://chatgpt.com/codex/tasks/task_e_683ff9db18048325a5c689ac500aa599