### PR TITLE
Add configurable service list

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'services' => ['apache2', 'mysql']
+];
+?>

--- a/monitor_data.php
+++ b/monitor_data.php
@@ -12,16 +12,13 @@ require_once 'metrics/connections.php';
 require_once 'metrics/ssl_certificates.php';
 require_once 'metrics/swap.php';
 
-
-
-
-
-
-
+// Configuración de la aplicación
+$config = require __DIR__ . '/config.php';
 
 // Obtener lista de servicios (Apache, MySQL, etc.)
 function obtenerServicios() {
-    $servicios = ['apache2', 'mysql'];
+    global $config;
+    $servicios = isset($config['services']) ? $config['services'] : [];
     $resultado = [];
 
     foreach ($servicios as $servicio) {

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,8 @@ Este proyecto es un **dashboard de monitorización** que muestra en tiempo real 
 
 3. **Configura las credenciales** de acceso en el archivo `auth.php`.
 
+4. **Define los servicios a vigilar** editando `config.php`.
+
 ---
 
 ## 🔐 **Protección del dashboard**
@@ -60,6 +62,17 @@ if (!isset($_SERVER['PHP_AUTH_USER']) || !isset($_SERVER['PHP_AUTH_PW']) ||
     echo 'Acceso denegado. Debe autenticarse para continuar.';
     exit;
 }
+```
+
+## ⚙️ **Personalizar servicios a vigilar**
+
+Edita `config.php` para indicar los servicios que deseas monitorizar.
+
+```php
+<?php
+return [
+    'services' => ['apache2', 'mysql']
+];
 ```
 
 ---


### PR DESCRIPTION
## Summary
- introduce `config.php` to store services to monitor
- load service list from config in `monitor_data.php`
- document how to customize services in the README

## Testing
- `php -l monitor_data.php`
- `php -l config.php`
- `sudo apt-get update`
- `sudo apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_e_683ffc5f63248325ab01ae4b1c3ae104