### PR TITLE
Improve security in network metrics and update docs

### DIFF
--- a/metrics/network.php
+++ b/metrics/network.php
@@ -14,15 +14,24 @@ function obtenerEstadisticasRed($interfaces = null) {
         $interfaces = array_map('trim', explode(',', $interfaces));
     }
 
+    $datos = file('/proc/net/dev');
     $rxTotal = 0;
     $txTotal = 0;
+
     foreach ($interfaces as $iface) {
-        $line = shell_exec("cat /proc/net/dev | grep {$iface}:");
-        if ($line) {
-            $parts = preg_split('/\s+/', trim(str_replace(':', ' ', $line)));
-            if (isset($parts[1]) && isset($parts[9])) {
-                $rxTotal += (int)$parts[1];
-                $txTotal += (int)$parts[9];
+        // Validar que el nombre de la interfaz contenga solo caracteres seguros
+        if (!preg_match('/^[a-zA-Z0-9:_-]+$/', $iface)) {
+            continue;
+        }
+
+        foreach ($datos as $linea) {
+            if (strpos($linea, $iface . ':') !== false) {
+                $parts = preg_split('/\s+/', trim(str_replace(':', ' ', $linea)));
+                if (isset($parts[1]) && isset($parts[9])) {
+                    $rxTotal += (int)$parts[1];
+                    $txTotal += (int)$parts[9];
+                }
+                break;
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,14 @@ Asegúrate de que el usuario del servidor tenga permisos para ejecutar estos com
 
 ---
 
+## 🔒 **Seguridad y buenas prácticas**
+
+El panel requiere autenticación básica y todas las contraseñas se almacenan como *hashes* utilizando `password_hash`.
+No obstante, muchas métricas se obtienen mediante `shell_exec`. Ejecuta el servidor web con un usuario sin privilegios y limita el acceso al dashboard.
+Para evitar inyección de comandos, la captura del tráfico de red se implementa leyendo directamente `/proc/net/dev` en lugar de invocar comandos externos.
+
+---
+
 ## 🤝 **Contribuciones**
 
 ¡Las contribuciones son bienvenidas! Si tienes ideas para mejorar este dashboard o encuentras un problema, crea un **issue** o envía un **pull request**.


### PR DESCRIPTION
## Summary
- sanitize network interface names and read `/proc/net/dev` directly to avoid command injection
- document security considerations in README

## Testing
- `php -l metrics/network.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684009b8acfc832594607c5be20d57ed